### PR TITLE
Changing None -> D1 in reprojection_tof.py

### DIFF
--- a/examples/Reprojection/reprojection_tof.py
+++ b/examples/Reprojection/reprojection_tof.py
@@ -105,7 +105,7 @@ def colorizeDepth(frameDepth, minDepth=MIN_DEPTH, maxDepth=MAX_DEPTH):
 
 def getAlignedDepth(frameDepth):
     R1, R2, _, _, _, _, _ = cv2.stereoRectify(M1, D1, M2, D2, (100, 100), R, T)  # The (100,100) doesn't matter as it is not used for calculating the rotation matrices
-    leftMapX, leftMapY = cv2.initUndistortRectifyMap(M1, None, R1, TARGET_MATRIX, tofSize, cv2.CV_32FC1)
+    leftMapX, leftMapY = cv2.initUndistortRectifyMap(M1, D1, R1, TARGET_MATRIX, tofSize, cv2.CV_32FC1)
     depthRect = cv2.remap(frameDepth, leftMapX, leftMapY, cv2.INTER_NEAREST)
     newR = np.dot(R2, np.dot(R, R1.T))  # Should be very close to identity
     newT = np.dot(R2, T)


### PR DESCRIPTION
The distortion coefficient was not used so the TOF depth was not undistorted and the alignment was slightly off